### PR TITLE
Add typedef for ssize_t under windows

### DIFF
--- a/buf.h
+++ b/buf.h
@@ -6,6 +6,11 @@
 #include <sys/types.h>
 #include <stdbool.h>
 
+#if defined(_MSC_VER)
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
+
 struct buf {
     char *data;
     size_t len, cap;


### PR DESCRIPTION
This fix allows the library to be compiled under windows as well.

I have only tested this under clang, not using msvc or any other windows-targetted compiler.